### PR TITLE
Add file conversion router and endpoint

### DIFF
--- a/src/ctk_api/core/utils.py
+++ b/src/ctk_api/core/utils.py
@@ -1,0 +1,61 @@
+"""Utility functions for the CTK API."""
+import logging
+import pathlib
+import tempfile
+
+import fastapi
+import pypandoc
+from fastapi import responses
+
+from ctk_api.core import config
+
+settings = config.get_settings()
+LOGGER_NAME = settings.LOGGER_NAME
+logger = logging.getLogger(LOGGER_NAME)
+
+
+def markdown_text_as_docx_response(
+    markdown_text: str,
+    background_tasks: fastapi.BackgroundTasks,
+    status_code: int,
+) -> responses.FileResponse:
+    """Converts markdown text to a docx file.
+
+    Args:
+        markdown_text: The markdown text to convert.
+        background_tasks: The FastAPI background tasks object.
+        status_code: The status code to return.
+
+    Returns:
+        The response with the docx file.
+    """
+    with tempfile.NamedTemporaryFile(
+        suffix=".docx",
+        delete=False,
+    ) as output_file, tempfile.NamedTemporaryFile(suffix=".md") as markdown_file:
+        markdown_file.write(markdown_text.encode("utf-8"))
+        markdown_file.seek(0)
+        pypandoc.convert_file(
+            markdown_file.name,
+            "docx",
+            outputfile=str(output_file.name),
+        )
+
+    background_tasks.add_task(_remove_file, output_file.name)
+    return responses.FileResponse(
+        output_file.name,
+        filename="md2docx.docx",
+        media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        background=background_tasks,
+        status_code=status_code,
+    )
+
+
+def _remove_file(filename: str | pathlib.Path) -> None:
+    """Removes a file.
+
+    Args:
+        filename: The filename of the file to remove.
+    """
+    logger.debug("Removing file %s.", filename)
+    pathlib.Path(filename).unlink()

--- a/src/ctk_api/main.py
+++ b/src/ctk_api/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware import cors
 from ctk_api.core import config, middleware
 from ctk_api.microservices import sql
 from ctk_api.routers.diagnoses import views as diagnoses_views
+from ctk_api.routers.file_conversion import views as file_conversion_views
 from ctk_api.routers.summarization import views as summarization_views
 
 settings = config.get_settings()
@@ -33,6 +34,7 @@ logger.info("Initializing API routes.")
 api_router = fastapi.APIRouter(prefix="/api/v1")
 api_router.include_router(diagnoses_views.router)
 api_router.include_router(summarization_views.router)
+api_router.include_router(file_conversion_views.router)
 
 logger.info("Starting API.")
 app = fastapi.FastAPI(

--- a/src/ctk_api/routers/file_conversion/__init__.py
+++ b/src/ctk_api/routers/file_conversion/__init__.py
@@ -1,0 +1,1 @@
+"""Definition of the file conversion router."""

--- a/src/ctk_api/routers/file_conversion/controller.py
+++ b/src/ctk_api/routers/file_conversion/controller.py
@@ -1,0 +1,32 @@
+"""View definitions for the file conversion router."""
+import logging
+
+import fastapi
+from fastapi import responses
+
+from ctk_api.core import config, utils
+
+settings = config.get_settings()
+LOGGER_NAME = settings.LOGGER_NAME
+
+logger = logging.getLogger(LOGGER_NAME)
+
+
+def markdown_to_docx(
+    markdown_text: str,
+    background_tasks: fastapi.BackgroundTasks,
+) -> responses.FileResponse:
+    """Converts markdown text to a docx file.
+
+    Args:
+        markdown_text: The markdown text to convert.
+        background_tasks: The FastAPI background tasks object.
+
+    Returns:
+        The response with the docx file.
+    """
+    return utils.markdown_text_as_docx_response(
+        markdown_text,
+        background_tasks,
+        status_code=200,
+    )

--- a/src/ctk_api/routers/file_conversion/views.py
+++ b/src/ctk_api/routers/file_conversion/views.py
@@ -1,0 +1,36 @@
+"""View definitions for the file conversion router."""
+import logging
+
+import fastapi
+from fastapi import responses
+
+from ctk_api.core import config
+from ctk_api.routers.file_conversion import controller
+
+settings = config.get_settings()
+LOGGER_NAME = settings.LOGGER_NAME
+
+logger = logging.getLogger(LOGGER_NAME)
+
+router = fastapi.APIRouter(prefix="/file_conversion", tags=["file_conversion"])
+
+
+@router.post("/md2docx")
+async def markdown_to_docx(
+    markdown_text: str = fastapi.Form(..., description="The markdown text to convert."),
+    background_tasks: fastapi.BackgroundTasks = fastapi.BackgroundTasks(),
+) -> responses.FileResponse:
+    """POST endpoint for converting markdown to .docx.
+
+    Args:
+        markdown_text: The markdown text to convert.
+        background_tasks: The FastAPI backgrond tasks object.
+
+    Returns:
+        str: The .docx file.
+
+    """
+    logger.debug("Converting Markdown to .docx")
+    response = controller.markdown_to_docx(markdown_text, background_tasks)
+    logger.debug("Converted Markdown to .docx.")
+    return response

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,6 +19,7 @@ class Endpoints(str, enum.Enum):
     POST_DIAGNOSIS = f"{API_ROOT}/diagnoses"  # noqa: PIE796
     PATCH_DIAGNOSIS = f"{API_ROOT}/diagnoses/{{diagnosis_id}}"
     DELETE_DIAGNOSIS = f"{API_ROOT}/diagnoses/{{diagnosis_id}}"  # noqa: PIE796
+    POST_MARKDOWN_TO_DOCX = f"{API_ROOT}/file_conversion/md2docx"
 
 
 @pytest.fixture()

--- a/tests/integration/test_file_conversion_endpoints.py
+++ b/tests/integration/test_file_conversion_endpoints.py
@@ -1,0 +1,37 @@
+"""Tests the diagnoses endpoints."""
+import pathlib
+
+import docx
+import pytest
+from fastapi import status, testclient
+
+from . import conftest
+
+
+@pytest.mark.asyncio()
+async def test_post_md2docx(
+    client: testclient.TestClient,
+    endpoints: conftest.Endpoints,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Tests the anonymization endpoint."""
+    md_text = "# Test Markdown Text"
+
+    response = client.post(
+        endpoints.POST_MARKDOWN_TO_DOCX,
+        data={"markdown_text": md_text},
+    )
+    with (tmp_path / "md2docx.docx").open("wb") as output_file:
+        output_file.write(response.content)
+        document = docx.Document(tmp_path / "md2docx.docx")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        response.headers["Content-Type"]
+        == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    assert (
+        response.headers["Content-Disposition"] == 'attachment; filename="md2docx.docx"'
+    )
+    assert document.paragraphs[0].text == md_text[2:]
+    assert document.paragraphs[0].style.name == "Heading 1"

--- a/tests/integration/test_summarization_endpoints.py
+++ b/tests/integration/test_summarization_endpoints.py
@@ -89,7 +89,7 @@ def test_summarization_endpoint_new(
         == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     )
     assert (
-        response.headers["Content-Disposition"] == 'attachment; filename="summary.docx"'
+        response.headers["Content-Disposition"] == 'attachment; filename="md2docx.docx"'
     )
 
 
@@ -110,5 +110,5 @@ def test_summarization_endpoint_exists(
         == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     )
     assert (
-        response.headers["Content-Disposition"] == 'attachment; filename="summary.docx"'
+        response.headers["Content-Disposition"] == 'attachment; filename="md2docx.docx"'
     )


### PR DESCRIPTION
This pull request adds a new file conversion router and endpoint to the API. The file conversion endpoint allows users to convert markdown text to a docx file. 