### PR TITLE
Fix database reset fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,14 +6,21 @@ import docx
 import pytest
 from sqlalchemy import orm
 
+from ctk_api.core import config
 from ctk_api.microservices import sql
+
+settings = config.get_settings()
+ENVIRONMENT = settings.ENVIRONMENT
 
 
 @pytest.fixture(autouse=True)
 def _reset_testing_db() -> None:
     """Resets the testing database."""
     database = sql.Database()
-    if database.get_db_url() != "sqlite:///tests/test.sqlite":
+    if (
+        database.get_db_url() != "sqlite:///tests/test.sqlite"
+        and ENVIRONMENT != "ci-testing"
+    ):
         msg = "Testing database is not configured correctly."
         raise ValueError(msg)
     sql.Base.metadata.drop_all(database.engine)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,13 @@ from sqlalchemy import orm
 from ctk_api.microservices import sql
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True)
 def _reset_testing_db() -> None:
     """Resets the testing database."""
     database = sql.Database()
+    if database.get_db_url() != "sqlite:///tests/test.sqlite":
+        msg = "Testing database is not configured correctly."
+        raise ValueError(msg)
     sql.Base.metadata.drop_all(database.engine)
     database.create_database_schema()
 


### PR DESCRIPTION
This pull request fixes the database reset fixture by adding a check to ensure that the testing database is configured correctly before dropping the tables. It also includes tests to verify that patching and deleting a diagnosis persist in the database correctly.